### PR TITLE
fix:修复上拉与下拉同时存在时，刷新头不能关闭

### DIFF
--- a/harmony/pull_to_refresh/src/main/cpp/RNCPullToRefreshInstance.cpp
+++ b/harmony/pull_to_refresh/src/main/cpp/RNCPullToRefreshInstance.cpp
@@ -182,7 +182,6 @@ void RNCPullToRefreshInstance::panGesture(ArkUI_NodeHandle arkUI_NodeHandle) {
 
         ArkUI_GestureEventActionType actionType = OH_ArkUI_GestureEvent_GetActionType(event);
         if (actionType == GESTURE_EVENT_ACTION_ACCEPT) {
-            instance->trYTop = 0;
             instance->offsetY = 0;
             instance->downY = OH_ArkUI_PanGesture_GetOffsetY(event);
             instance->touchYOld = instance->offsetY;
@@ -235,7 +234,7 @@ void RNCPullToRefreshInstance::onActionPullUpdate() {
 
 void RNCPullToRefreshInstance::onActionPullEnd() {
     auto maxTranslate = MAX_TRANSLATE;
-    if (trYTop > 0) {
+    if (trYTop > 0 && up_status == Up_FREE) {
         if (state == FREE || state == PULL_DOWN_1 || state == PULL_DOWN_2) {
             if (trYTop / maxTranslate < 0.5) {
                 closeHeaderRefresh(0, PULL_HEADER);
@@ -251,7 +250,7 @@ void RNCPullToRefreshInstance::onActionPullEnd() {
 }
 void RNCPullToRefreshInstance::onActionUpEnd() {
     auto maxTranslate = MAX_TRANSLATE;
-    if (trYTop > 0) {
+    if (trYTop > 0 && state == FREE) {
         if (up_status == Up_FREE || up_status == Up_PULL_DOWN_1 || up_status == Up_PULL_DOWN_2) {
             if ((trYTop / maxTranslate < 0.5) || (m_footerInstance && m_footerInstance->isNoMoreData())) {
                 closeHeaderRefresh(0, PULL_FOOTER);
@@ -352,7 +351,7 @@ bool RNCPullToRefreshInstance::isComponentTop() {
         if (c->getComponentName() == "ScrollView") {
             auto scrollView = std::dynamic_pointer_cast<rnoh::ScrollViewComponentInstance>(c);
             if (scrollView != nullptr) {
-                return scrollView->getScrollViewMetrics().contentOffset.y <= 0;
+                return scrollView->getScrollViewMetrics().contentOffset.y <= 0 && up_status == Up_FREE;
             }
         }
     }
@@ -368,7 +367,7 @@ bool RNCPullToRefreshInstance::isComponentBottom() {
                 // 内容高度-可视高度
                 auto maxScrollHeight = scrollView->getScrollViewMetrics().contentSize.height -
                                        scrollView->getScrollViewMetrics().containerSize.height;
-                return scrollView->getScrollViewMetrics().contentOffset.y >= maxScrollHeight - 10;
+                return scrollView->getScrollViewMetrics().contentOffset.y >= maxScrollHeight - 10 && state == FREE;
             }
         }
     }
@@ -421,6 +420,7 @@ void RNCPullToRefreshInstance::onOffsetChanged(bool isHeader, float offset) {
 
 void RNCPullToRefreshInstance::closeHeaderRefresh(float target, int closeTag) {
     if (trYTop == target) {
+        DLOG(INFO)<<"pull-to-refresh closeHeaderRefresh trYTop:"<<trYTop << ";target:"<<target;
         return;
     }
     if (animation != nullptr && (animation->GetAnimationStatus() == CLOSE_ANIMATION_START ||


### PR DESCRIPTION
# Summary

- fix:修复上拉与下拉同时存在时，刷新头不能关闭

## Checklist

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例
- [ ] 已经更新了文档
- [ ] 更新了 JS/TS 代码
