### PR TITLE
fix:修复77上header或者foolter直接包裹一个view显示的问题

### DIFF
--- a/harmony/pull_to_refresh/src/main/cpp/RNCPullToRefreshFooterInstance.cpp
+++ b/harmony/pull_to_refresh/src/main/cpp/RNCPullToRefreshFooterInstance.cpp
@@ -24,10 +24,8 @@ RNCPullToRefreshFooterInstance::~RNCPullToRefreshFooterInstance() { m_pullToRefr
 
 void RNCPullToRefreshFooterInstance::onChildInserted(ComponentInstance::Shared const &childComponentInstance,
                                                      std::size_t index) {
-    childComponentInstance->getLocalRootArkUINode().setPosition({0, 0});
     CppComponentInstance::onChildInserted(childComponentInstance, index);
     m_footerStackNode.insertChild(childComponentInstance->getLocalRootArkUINode(), index);
-    m_footerStackNode.setPosition({0, 0});
 }
 
 void RNCPullToRefreshFooterInstance::onChildRemoved(ComponentInstance::Shared const &childComponentInstance) {
@@ -44,6 +42,9 @@ void RNCPullToRefreshFooterInstance::finalizeUpdates() {
             if (height > mChildHeight) {
                 mChildHeight = height;
             }
+            auto x = c->getLayoutMetrics().frame.origin.x > 0 ? c->getLayoutMetrics().frame.origin.x: 0;
+            auto y = c->getLayoutMetrics().frame.origin.y > 0 ? c->getLayoutMetrics().frame.origin.y: 0;
+            c->getLocalRootArkUINode().setPosition({x, y});
         }
     }
     double pointScaleFactor = getLayoutMetrics().pointScaleFactor;

--- a/harmony/pull_to_refresh/src/main/cpp/RNCPullToRefreshHeaderInstance.cpp
+++ b/harmony/pull_to_refresh/src/main/cpp/RNCPullToRefreshHeaderInstance.cpp
@@ -29,7 +29,6 @@ RNCPullToRefreshHeaderInstance::RNCPullToRefreshHeaderInstance(Context context)
 RNCPullToRefreshHeaderInstance::~RNCPullToRefreshHeaderInstance() { m_pullToRefreshNodeDelegate = nullptr; }
 void RNCPullToRefreshHeaderInstance::onChildInserted(ComponentInstance::Shared const &childComponentInstance,
                                                      std::size_t index) {
-    childComponentInstance->getLocalRootArkUINode().setPosition({0, 0});
     CppComponentInstance::onChildInserted(childComponentInstance, index);
     m_headerStackNode.insertChild(childComponentInstance->getLocalRootArkUINode(), index);
 }
@@ -49,6 +48,9 @@ void RNCPullToRefreshHeaderInstance::finalizeUpdates() {
             if (height > childHeight) {
                 childHeight = height;
             }
+            auto x = c->getLayoutMetrics().frame.origin.x > 0 ? c->getLayoutMetrics().frame.origin.x: 0;
+            auto y = c->getLayoutMetrics().frame.origin.y > 0 ? c->getLayoutMetrics().frame.origin.y: 0;
+            c->getLocalRootArkUINode().setPosition({x, y});
         }
     }
     double pointScaleFactor = getLayoutMetrics().pointScaleFactor;


### PR DESCRIPTION
# Summary

- fix:修复77上header或者foolter直接包裹一个view显示的问题
- Closed: #20 


## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)